### PR TITLE
feat: treat local environment as development

### DIFF
--- a/src/EnvironmentIndicatorPlugin.php
+++ b/src/EnvironmentIndicatorPlugin.php
@@ -42,7 +42,7 @@ class EnvironmentIndicatorPlugin implements Plugin
         $plugin->color(fn () => match (app()->environment()) {
             'production' => Color::Red,
             'staging' => Color::Orange,
-            'development' => Color::Blue,
+            'development', 'local' => Color::Blue,
             default => Color::Pink,
         });
 


### PR DESCRIPTION
In a default Laravel installation, a dev environment uses '[local](https://github.com/laravel/laravel/blob/10.x/.env.example#L2)', so I think it's fair to treat it as development environment in this package too.