### PR TITLE
Add git branch name to badge display

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -91,6 +91,20 @@ $panel->plugins([
 ]);
 ```
 
+### Git Branch
+
+You can enable the display of the current git branch in the badge via `->showGitBranch()`. This requires the `exec()` function to be enabled in your PHP configuration.
+
+```php
+use pxlrbt\FilamentEnvironmentIndicator\EnvironmentIndicatorPlugin;
+use Filament\Support\Colors\Color;
+
+$panel->plugins([
+    EnvironmentIndicatorPlugin::make()
+        ->showGitBranch()                    
+]);
+```
+
 ## Contributing
 
 If you want to contribute to this packages, you may want to test it in a real Filament project:

--- a/resources/views/badge.blade.php
+++ b/resources/views/badge.blade.php
@@ -13,4 +13,8 @@
     "
 >
     {{ $environment }}
+    @if(isset($branch))
+        <code class="">&nbsp;({{ $branch }})</code>
+    @endif
+
 </div>

--- a/resources/views/badge.blade.php
+++ b/resources/views/badge.blade.php
@@ -13,8 +13,8 @@
     "
 >
     {{ $environment }}
-    @if(isset($branch))
-        <code class="">&nbsp;({{ $branch }})</code>
-    @endif
 
+    @isset($branch)
+        <code class="text-xs ml-1" style="margin-top: 1px">({{ $branch }})</code>
+    @endisset
 </div>

--- a/src/EnvironmentIndicatorPlugin.php
+++ b/src/EnvironmentIndicatorPlugin.php
@@ -9,6 +9,7 @@ use Filament\Support\Colors\Color;
 use Filament\Support\Concerns\EvaluatesClosures;
 use Illuminate\Support\Facades\View;
 use Illuminate\Support\HtmlString;
+use Throwable;
 
 class EnvironmentIndicatorPlugin implements Plugin
 {
@@ -158,9 +159,10 @@ class EnvironmentIndicatorPlugin implements Plugin
         if (! $this->evaluate($this->showGitBranch)) {
             return null;
         }
+
         try {
             return trim(exec('git branch --show-current'));
-        } catch (\Throwable $th) {
+        } catch (Throwable $th) {
             return null;
         }
     }

--- a/src/EnvironmentIndicatorPlugin.php
+++ b/src/EnvironmentIndicatorPlugin.php
@@ -22,6 +22,8 @@ class EnvironmentIndicatorPlugin implements Plugin
 
     public array|Closure|null $color = null;
 
+    public bool|Closure|null $showGitBranch = null;
+
     public static function make(): static
     {
         $plugin = app(static::class);
@@ -83,6 +85,7 @@ class EnvironmentIndicatorPlugin implements Plugin
             return View::make('filament-environment-indicator::badge', [
                 'color' => $this->getColor(),
                 'environment' => ucfirst(app()->environment()),
+                'branch' => $this->getGitBranch()
             ]);
         });
 
@@ -131,6 +134,13 @@ class EnvironmentIndicatorPlugin implements Plugin
         return $this;
     }
 
+    public function showGitBranch(bool|Closure $showGitBranch = true): static
+    {
+        $this->showGitBranch = $showGitBranch;
+
+        return $this;
+    }
+
     public function color(array|Closure $color = Color::Pink): static
     {
         $this->color = $color;
@@ -141,5 +151,17 @@ class EnvironmentIndicatorPlugin implements Plugin
     protected function getColor(): array
     {
         return $this->evaluate($this->color);
+    }
+
+    protected function getGitBranch(): ?string
+    {
+        if (! $this->evaluate($this->showGitBranch)) {
+            return null;
+        }
+        try {
+            return trim(exec('git branch --show-current'));
+        } catch (\Throwable $th) {
+            return null;
+        }
     }
 }


### PR DESCRIPTION
This pull request adds functionality to append the name of the currently checked out git branch to the end of the environment display badge, i.e.: `Local (main)`.

Users can opt in by changing the `->showGitBranch()` method to the plugin in the panel provider.

This PR serves to further enhance developer awareness when utilizing the Environment Indicator plugin.