### PR TITLE
Mark the `prod` environment as unsafe

### DIFF
--- a/src/EnvironmentIndicatorPlugin.php
+++ b/src/EnvironmentIndicatorPlugin.php
@@ -47,12 +47,12 @@ class EnvironmentIndicatorPlugin implements Plugin
         });
 
         $plugin->showBadge(fn () => match (app()->environment()) {
-            'production', 'prod' => false,
+            'production' => false,
             default => true,
         });
 
         $plugin->showBorder(fn () => match (app()->environment()) {
-            'production', 'prod' => false,
+            'production' => false,
             default => true,
         });
 


### PR DESCRIPTION
The `prod` environment is not the production environment in Laravel. When the application environment is set to `prod`, Laravel does not protect sensitive Artisan commands and other operations. Therefore, the `prod` environment should be marked as unsafe.