### PR TITLE
fix: set default of TRUE for badge and border

### DIFF
--- a/src/EnvironmentIndicatorPlugin.php
+++ b/src/EnvironmentIndicatorPlugin.php
@@ -49,15 +49,9 @@ class EnvironmentIndicatorPlugin implements Plugin
             default => Color::Pink,
         });
 
-        $plugin->showBadge(fn () => match (app()->environment()) {
-            'production' => false,
-            default => true,
-        });
+        $plugin->showBadge(true);
 
-        $plugin->showBorder(fn () => match (app()->environment()) {
-            'production' => false,
-            default => true,
-        });
+        $plugin->showBorder(true);
 
         return $plugin;
     }


### PR DESCRIPTION
This change matches the documentation which says "By default, both indicators are displayed".

This also **matches my expectations** for the plugin functionality. I wanted a banner to be displayed on production and local, so I could visually identify each environment easily.