### PR TITLE
Fix: border indicator

### DIFF
--- a/src/EnvironmentIndicatorPlugin.php
+++ b/src/EnvironmentIndicatorPlugin.php
@@ -114,9 +114,8 @@ class EnvironmentIndicatorPlugin implements Plugin
 
             return new HtmlString("
                 <style>
-                    .fi-topbar,
-                    .fi-sidebar {
-                        border-top: 5px solid rgb({$this->getColor()['500']}) !important;
+                    .fi-topbar {
+                        border-top: 5px solid {$this->getColor()['500']} !important;
                     }
 
                     .fi-topbar {


### PR DESCRIPTION
Hi,

1. `$this->getColor()['500']` already returns `oklch` so additional `rgb()` causes border is not displaying.
2. There is no need to add border to `.fi-sidebar`, because layout in FilamentPHP v4 is different, so coloring `.fa-sidebar` causes this: <img width="778" height="309" alt="image" src="https://github.com/user-attachments/assets/8e3204d6-117a-4d7a-b71f-f0a71396f633" />

