### PR TITLE
[Filament v4] Remove topbar height constraint.

### DIFF
--- a/src/EnvironmentIndicatorPlugin.php
+++ b/src/EnvironmentIndicatorPlugin.php
@@ -117,10 +117,6 @@ class EnvironmentIndicatorPlugin implements Plugin
                     .fi-topbar {
                         border-top: 5px solid {$this->getColor()['500']} !important;
                     }
-
-                    .fi-topbar {
-                        height: calc(4rem + 5px) !important;
-                    }
                 </style>
             ");
         });


### PR DESCRIPTION
Hi, thanks for your work. 
When updating to filament v4, the plugin makes a scrollbar appearing.


https://github.com/user-attachments/assets/cc8a5bab-78c1-46ba-b50b-6a955884a7e5

I'm not sure what was the purpose of the topbar height constraint, but removing it fixes the issue.

Thanks,
Mathieu.