### PR TITLE
Add additional shades

### DIFF
--- a/resources/views/badge.blade.php
+++ b/resources/views/badge.blade.php
@@ -7,7 +7,7 @@
         fi-badge fi-color fi-text-color-600
         dark:fi-text-color-400
     "
-    style="{{ get_color_css_variables($color, [50, 100, 200, 300, 400, 500, 600, 700])  }}"
+    style="{{ get_color_css_variables($color, [50, 100, 200, 300, 400, 500, 600, 700, 800, 900, 950])  }}"
 >
     {{ $environment }}
 

--- a/resources/views/debug-mode-warning.blade.php
+++ b/resources/views/debug-mode-warning.blade.php
@@ -10,7 +10,7 @@
         fi-badge fi-color fi-text-color-600
         dark:fi-text-color-400
     "
-    style="{{ get_color_css_variables(Color::Red, [50, 100, 200, 300, 400, 500, 600, 700])  }}"
+    style="{{ get_color_css_variables(Color::Red, [50, 100, 200, 300, 400, 500, 600, 700, 800, 900, 950])  }}"
 >
     {{ generate_icon_html(Heroicon::OutlinedExclamationTriangle) }}
     Debug Mode


### PR DESCRIPTION
The filament minimal theme requires shade 100 and the Lucent theme requires shade 700. I added 200 as well which I think should cover most themes. 