### PR TITLE
Fix color format in topbar border style

### DIFF
--- a/src/EnvironmentIndicatorPlugin.php
+++ b/src/EnvironmentIndicatorPlugin.php
@@ -118,7 +118,7 @@ class EnvironmentIndicatorPlugin implements Plugin
             return new HtmlString("
                 <style>
                     .fi-topbar {
-                        border-top: {$this->evaluate($this->borderWidth)}px solid rgb({$this->getColor()['500']}) !important;
+                        border-top: {$this->evaluate($this->borderWidth)}px solid {$this->getColor()['500']} !important;
                     }
                 </style>
             ");


### PR DESCRIPTION
Hey,
#29 broke the topbar border by adding the rgb function.
The result is:
<img width="347" height="91" alt="Screenshot 2025-11-12 at 21 13 08" src="https://github.com/user-attachments/assets/1b79a296-ead2-4e36-80b6-a125dcf5657d" />

which is invalid css.

Thanks,
Mathieu