### PR TITLE
Allow customizing environment detection in EnvironmentIndicatorPlugin

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -59,6 +59,21 @@ $panel->plugins([
 ]);
 ```
 
+### Environment
+
+By default, the environment is resolved from `app()->environment()` (i.e. the `APP_ENV` value). You can override it with a static string or a closure:
+
+```php
+use pxlrbt\FilamentEnvironmentIndicator\EnvironmentIndicatorPlugin;
+
+$panel->plugins([
+    EnvironmentIndicatorPlugin::make()
+        ->environment(fn () => config('app.custom_env', app()->environment()))
+]);
+```
+
+This affects the badge label, as well as the default color, badge visibility, and border visibility which all key off the environment value.
+
 ### Colors
 
 You can overwrite the default colors if you want your own colors or need to add more. The `->color()`method accepts any Filament's Color object or a closure that returns a color object.

--- a/src/EnvironmentIndicatorPlugin.php
+++ b/src/EnvironmentIndicatorPlugin.php
@@ -31,6 +31,8 @@ class EnvironmentIndicatorPlugin implements Plugin
 
     public int|Closure|null $borderWidth = 5;
 
+    public string|Closure|null $environment = null;
+
     public static function make(): static
     {
         $plugin = app(static::class);
@@ -48,19 +50,19 @@ class EnvironmentIndicatorPlugin implements Plugin
             return true;
         });
 
-        $plugin->color(fn () => match (app()->environment()) {
+        $plugin->color(fn () => match ($plugin->getEnvironment()) {
             'production' => Color::Red,
             'staging' => Color::Orange,
             'development' => Color::Blue,
             default => Color::Pink,
         });
 
-        $plugin->showBadge(fn () => match (app()->environment()) {
+        $plugin->showBadge(fn () => match ($plugin->getEnvironment()) {
             'production' => false,
             default => true,
         });
 
-        $plugin->showBorder(fn () => match (app()->environment()) {
+        $plugin->showBorder(fn () => match ($plugin->getEnvironment()) {
             'production' => false,
             default => true,
         });
@@ -90,7 +92,7 @@ class EnvironmentIndicatorPlugin implements Plugin
             if ($this->evaluate($this->showDebugModeWarning) && app()->hasDebugModeEnabled()) {
                 $html .= view('filament-environment-indicator::debug-mode-warning', [
                     'color' => $this->getColor(),
-                    'environment' => ucfirst(app()->environment()),
+                    'environment' => ucfirst($this->getEnvironment()),
                     'branch' => $this->getGitBranch(),
                 ])->render();
             }
@@ -98,7 +100,7 @@ class EnvironmentIndicatorPlugin implements Plugin
             if ($this->evaluate($this->showBadge)) {
                 $html .= view('filament-environment-indicator::badge', [
                     'color' => $this->getColor(),
-                    'environment' => ucfirst(app()->environment()),
+                    'environment' => ucfirst($this->getEnvironment()),
                     'branch' => $this->getGitBranch(),
                 ])->render();
             }
@@ -209,5 +211,17 @@ class EnvironmentIndicatorPlugin implements Plugin
         $this->borderWidth = $borderWidth;
 
         return $this;
+    }
+
+    public function environment(string|Closure $environment): static
+    {
+        $this->environment = $environment;
+
+        return $this;
+    }
+
+    public function getEnvironment(): string
+    {
+        return $this->evaluate($this->environment) ?? app()->environment();
     }
 }


### PR DESCRIPTION
## Summary
This PR adds the ability to customize how the environment is detected in the EnvironmentIndicatorPlugin, allowing users to override the default `app()->environment()` behavior with a static string or closure.

## Key Changes
- Added a new `$environment` property to store the custom environment value
- Added `environment(string|Closure $environment)` method to configure a custom environment resolver
- Added `getEnvironment()` method that evaluates the custom environment or falls back to `app()->environment()`
- Updated all references to `app()->environment()` throughout the plugin to use `$plugin->getEnvironment()` instead
- Updated documentation with usage examples showing how to override environment detection