### PR TITLE
feat: add showGitInfo() for git tag and hash display

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -135,6 +135,27 @@ $panel->plugins([
 ]);
 ```
 
+### Git Info (tag, hash, custom)
+
+For anything beyond the branch — a git tag, the short commit hash, or a custom combination — use `->showGitInfo()`. It receives a `GitInfo` instance exposing `branch()`, `tag()` and `hash()` (each resolved lazily via `exec()` and cached), and returns the string to render in the badge. Any lookup returns `null` when unavailable, so guard accordingly.
+
+```php
+use pxlrbt\FilamentEnvironmentIndicator\EnvironmentIndicatorPlugin;
+use pxlrbt\FilamentEnvironmentIndicator\GitInfo;
+
+$panel->plugins([
+    EnvironmentIndicatorPlugin::make()
+        // e.g. "2.2.0 - 12345678", or just the hash on dev
+        ->showGitInfo(fn (GitInfo $git) => match (app()->environment()) {
+            'production' => $git->tag().' - '.$git->hash(),
+            'staging' => ($git->tag() ?? $git->branch()).' - '.$git->hash(),
+            default => $git->hash(),
+        })
+]);
+```
+
+`->showGitBranch()` is a convenience wrapper around this same mechanism. `->showGitInfo()` takes precedence when both are set. Long values are truncated in the badge to keep it compact; the full value is shown on hover.
+
 ### Debug Mode Warning
 
 You can enable a debug mode warning for every environment or just for production by using `->showDebugModeWarning()`/`->showDebugModeWarningInProduction()`

--- a/resources/css/styles.css
+++ b/resources/css/styles.css
@@ -10,6 +10,14 @@
         margin-block-start: 1px;
         margin-inline-start: 0.25rem;
         font-size: var(--text-xs);
+
+        /* Keep the badge compact: truncate long tags/hashes, full value on hover. */
+        display: inline-block;
+        max-width: 12rem;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+        vertical-align: bottom;
     }
 }
 

--- a/resources/views/badge.blade.php
+++ b/resources/views/badge.blade.php
@@ -12,6 +12,6 @@
     {{ $environment }}
 
     @isset($branch)
-        <code>({{ $branch }})</code>
+        <code title="{{ $branch }}">({{ $branch }})</code>
     @endisset
 </div>

--- a/src/EnvironmentIndicatorPlugin.php
+++ b/src/EnvironmentIndicatorPlugin.php
@@ -9,7 +9,6 @@ use Filament\Support\Colors\Color;
 use Filament\Support\Concerns\EvaluatesClosures;
 use Filament\View\PanelsRenderHook;
 use Illuminate\Support\HtmlString;
-use Throwable;
 
 class EnvironmentIndicatorPlugin implements Plugin
 {
@@ -26,6 +25,8 @@ class EnvironmentIndicatorPlugin implements Plugin
     public ?string $badgePosition = null;
 
     public bool|Closure|null $showGitBranch = null;
+
+    public ?Closure $gitInfo = null;
 
     public bool|Closure|null $showDebugModeWarning = null;
 
@@ -93,7 +94,7 @@ class EnvironmentIndicatorPlugin implements Plugin
                 $html .= view('filament-environment-indicator::debug-mode-warning', [
                     'color' => $this->getColor(),
                     'environment' => ucfirst($this->getEnvironment()),
-                    'branch' => $this->getGitBranch(),
+                    'branch' => $this->resolveGitInfo(),
                 ])->render();
             }
 
@@ -101,7 +102,7 @@ class EnvironmentIndicatorPlugin implements Plugin
                 $html .= view('filament-environment-indicator::badge', [
                     'color' => $this->getColor(),
                     'environment' => ucfirst($this->getEnvironment()),
-                    'branch' => $this->getGitBranch(),
+                    'branch' => $this->resolveGitInfo(),
                 ])->render();
             }
 
@@ -162,6 +163,20 @@ class EnvironmentIndicatorPlugin implements Plugin
         return $this;
     }
 
+    /**
+     * Display custom git information in the badge. The closure receives a
+     * GitInfo instance (also injectable by type) exposing branch(), tag()
+     * and hash(), and returns the string to render.
+     *
+     * Example: ->showGitInfo(fn (GitInfo $git) => $git->tag().' - '.$git->hash())
+     */
+    public function showGitInfo(Closure $callback): static
+    {
+        $this->gitInfo = $callback;
+
+        return $this;
+    }
+
     public function showDebugModeWarning(bool|Closure $showWarning = true): static
     {
         $this->showDebugModeWarning = $showWarning;
@@ -208,17 +223,28 @@ class EnvironmentIndicatorPlugin implements Plugin
         return $this->evaluate($this->color);
     }
 
-    protected function getGitBranch(): ?string
+    /**
+     * Resolve the git string shown in the badge.
+     *
+     * A ->showGitInfo() closure takes precedence; otherwise ->showGitBranch()
+     * falls back to the branch name (implemented on top of the same GitInfo).
+     * Returns null when neither is enabled, so the view renders nothing.
+     */
+    protected function resolveGitInfo(): ?string
     {
-        if (! $this->evaluate($this->showGitBranch)) {
-            return null;
+        $git = new GitInfo;
+
+        if ($this->gitInfo !== null) {
+            $result = $this->evaluate($this->gitInfo, ['git' => $git], [GitInfo::class => $git]);
+
+            return $result === null || $result === '' ? null : (string) $result;
         }
 
-        try {
-            return trim(exec('git branch --show-current'));
-        } catch (Throwable $th) {
-            return null;
+        if ($this->evaluate($this->showGitBranch)) {
+            return $git->branch();
         }
+
+        return null;
     }
 
     public function borderWidth(int|Closure $borderWidth = 5): static

--- a/src/GitInfo.php
+++ b/src/GitInfo.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace pxlrbt\FilamentEnvironmentIndicator;
+
+use Throwable;
+
+/**
+ * Lazily resolves git information for the environment badge.
+ *
+ * Each lookup shells out via exec() at most once and caches the result.
+ * exec() may be disabled or fail, so every lookup degrades to null.
+ */
+class GitInfo
+{
+    /** @var array<string, string|null> */
+    protected array $cache = [];
+
+    /**
+     * The current branch name (e.g. "main"), or null when detached/unavailable.
+     */
+    public function branch(): ?string
+    {
+        return $this->run('branch', 'git branch --show-current');
+    }
+
+    /**
+     * The nearest tag reachable from HEAD (e.g. "2.2.0"), or null when no tag exists.
+     */
+    public function tag(): ?string
+    {
+        return $this->run('tag', 'git describe --tags --abbrev=0');
+    }
+
+    /**
+     * The short commit hash of HEAD (e.g. "12345678"), or null when unavailable.
+     */
+    public function hash(): ?string
+    {
+        return $this->run('hash', 'git rev-parse --short HEAD');
+    }
+
+    protected function run(string $key, string $command): ?string
+    {
+        if (array_key_exists($key, $this->cache)) {
+            return $this->cache[$key];
+        }
+
+        try {
+            $result = trim((string) exec($command));
+
+            return $this->cache[$key] = ($result === '' ? null : $result);
+        } catch (Throwable $th) {
+            return $this->cache[$key] = null;
+        }
+    }
+}


### PR DESCRIPTION
Adds a general ->showGitInfo(Closure) method that receives a lazy GitInfo instance (branch(), tag(), hash()) and returns the string to render in the badge. This enables displaying the git tag and/or short commit hash, e.g. "2.2.0 - 12345678", in addition to the branch.

->showGitBranch() is now a convenience wrapper over the same GitInfo mechanism and keeps its existing behavior (no breaking change). Both can be combined via showGitInfo(). Git lookups remain opt-in and degrade to null when exec() is unavailable.

Long values are truncated in the badge (with the full value on hover) to keep it compact, per maintainer guidance.

Closes #27